### PR TITLE
Add Episode 5 exercises

### DIFF
--- a/episodes/troubleshooting.md
+++ b/episodes/troubleshooting.md
@@ -33,10 +33,11 @@ Objectives
 ::::{dropdown} How did it go?
 :open:
 
-In pairs, discuss the following points:
+Take a few minutes to reflect on your experience following the training on your own then, in pairs, discuss the following points:
 
 - What did you learn that was new to you?
-- Are there any points that were unclear?
+- What was confusing about the training?
+- What questions do you have about hub management?
 - Which areas would you like to explore further?
 - Do you think your users would benefit from this lesson?
 
@@ -50,8 +51,8 @@ Prepare to summarise and share with the rest of the workshop.
 A user wants to use a software application that is not currently available on the hub. Rearrange the following statements in the order of action you would escalate support for this person:
 
 1. Contact the 2i2c technical support desk for assistance
-1. Signpost the user to the relevant documentation in the 2i2c Service Guide
-1. Arrange one-to-one support to guide the user through the process of pulling a custom container to the hub
+1. Direct the user to the relevant documentation in the 2i2c Service Guide
+1. Provide one-to-one support to guide the user through the process of pulling a custom container to the hub
 1. Find a custom container that includes the requested software application and provide the information needed to pull this container to the hub to the user
 
 :::{dropdown} Solution
@@ -65,7 +66,7 @@ There are different ways in which you can approach this support request dependin
 ::::{dropdown} Plan your support process
 :open:
 
-Build a plan for how you will support the use of your hub amongst your community. Here are some things to consider:
+Build a plan for how you will support the use of your hub amongst your community. Begin by trying to answer the following questions:
 
 - How will you communicate with your users?
 - Where will your users report issues?
@@ -74,6 +75,15 @@ Build a plan for how you will support the use of your hub amongst your community
 - What resources are available to help you when you need help?
 - When should you ask for technical assistance from 2i2c?
 - How much time can you commit to support activities?
+
+Considering your responses to the prompts above, identify which of the following resources you already have access to and which you would need to create/obtain:
+
+- communications platforms and channels
+- tools for tracking issues/support requests
+- documentation
+- training
+
+Is there anything else you need, to support hub users?
 
 ::::
 

--- a/episodes/troubleshooting.md
+++ b/episodes/troubleshooting.md
@@ -22,13 +22,60 @@ Questions
 :::{grid-item}
 Objectives
 
-- triage common problems and know where to look for help
 - share learning experiences from their self-guided study
+- triage common problems and know where to look for help
 - plan a sustainable support strategy for their community
 
 :::
 
 :::::
+
+::::{dropdown} How did it go?
+:open:
+
+In pairs, discuss the following points:
+
+- What did you learn that was new to you?
+- Are there any points that were unclear?
+- Which areas would you like to explore further?
+- Do you think your users would benefit from this lesson?
+
+Prepare to summarise and share with the rest of the workshop.
+
+::::
+
+::::{dropdown} Where to go for help?
+:open:
+
+A user wants to use a software application that is not currently available on the hub. Rearrange the following statements in the order of action you would escalate support for this person:
+
+1. Contact the 2i2c technical support desk for assistance
+1. Signpost the user to the relevant documentation in the 2i2c Service Guide
+1. Arrange one-to-one support to guide the user through the process of pulling a custom container to the hub
+1. Find a custom container that includes the requested software application and provide the information needed to pull this container to the hub to the user
+
+:::{dropdown} Solution
+
+There are different ways in which you can approach this support request depending on your technical capacity and your own judgement. However we recommend that you *Contact the 2i2c technical support desk for assistance* as a last resort.
+
+:::
+
+::::
+
+::::{dropdown} Plan your support process
+:open:
+
+Build a plan for how you will support the use of your hub amongst your community. Here are some things to consider:
+
+- How will you communicate with your users?
+- Where will your users report issues?
+- What needs do you anticipate from your users? How can you set them up for success?
+- How will you track whether an issue gets resolved?
+- What resources are available to help you when you need help?
+- When should you ask for technical assistance from 2i2c?
+- How much time can you commit to support activities?
+
+::::
 
 :::{card} 
 KEY POINTS
@@ -36,6 +83,5 @@ KEY POINTS
 After following this episode, learners will be able to...
 
 - triage problems encountered by hub users
-- Use Grafana to measure hub usage
 - choose the most appropriate place to look or ask for help with hub management
 :::


### PR DESCRIPTION
Adding Episode 5 exercises. Related issue https://github.com/czi-catalystproject/hub-champion-training/issues/12.

**Exercise 1**

This reflection exercise is designed to collate experiences from the self-guided study portion of the workshop and identify common experiences. The most common issue identified will be used by the instructor to demonstrate troubleshooting in a "flipped classroom" style experience. 

**Exercise 2**

This is a variation of the Parsons Problem exercise type that addresses the support pathways a Hub Champion can provide and where to look for help.

**Exercise 3**

This reflection exercise is designed to stimulate Hub Champions to take some concrete steps towards devising a strategy for their community

> Episode 5 objectives
> - share learning experiences from their self-guided study
> - triage common problems and know where to look for help
> - plan a sustainable support strategy for their community