### PR TITLE
Upload media folder to Crowdin

### DIFF
--- a/.github/workflows/crowdin-action-upload.yml
+++ b/.github/workflows/crowdin-action-upload.yml
@@ -3,7 +3,8 @@ name: Upload sources to Crowdin
 on:
   push:
     paths:
-      - locale/es_LA/**  
+      - locale/es_LA/**
+      - media/**
     branches: [ main ]
     
 permissions:


### PR DESCRIPTION
Media assets such as images also need to be localised.